### PR TITLE
1951: Update the PufferL2Depositor and PufLocker contracts and their handlers

### DIFF
--- a/lib/contracts/abis/mainnet/PufLocker.ts
+++ b/lib/contracts/abis/mainnet/PufLocker.ts
@@ -210,6 +210,7 @@ export const PufLocker = <const>[
   {
     inputs: [
       { internalType: 'address', name: 'token', type: 'address' },
+      { internalType: 'address', name: 'recipient', type: 'address' },
       { internalType: 'uint128', name: 'lockPeriod', type: 'uint128' },
       {
         components: [

--- a/lib/contracts/abis/mainnet/PufferL2Depositor.ts
+++ b/lib/contracts/abis/mainnet/PufferL2Depositor.ts
@@ -3,6 +3,7 @@ export const PufferL2Depositor = <const>[
     inputs: [
       { internalType: 'address', name: 'accessManager', type: 'address' },
       { internalType: 'address', name: 'weth', type: 'address' },
+      { internalType: 'contract IPufLocker', name: 'locker', type: 'address' },
     ],
     stateMutability: 'nonpayable',
     type: 'constructor',
@@ -172,6 +173,15 @@ export const PufferL2Depositor = <const>[
   },
   {
     inputs: [],
+    name: 'PUFFER_LOCKER',
+    outputs: [
+      { internalType: 'contract IPufLocker', name: '', type: 'address' },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
     name: 'WETH',
     outputs: [{ internalType: 'address', name: '', type: 'address' }],
     stateMutability: 'view',
@@ -208,6 +218,7 @@ export const PufferL2Depositor = <const>[
         type: 'tuple',
       },
       { internalType: 'uint256', name: 'referralCode', type: 'uint256' },
+      { internalType: 'uint128', name: 'lockPeriod', type: 'uint128' },
     ],
     name: 'deposit',
     outputs: [],
@@ -218,6 +229,7 @@ export const PufferL2Depositor = <const>[
     inputs: [
       { internalType: 'address', name: 'account', type: 'address' },
       { internalType: 'uint256', name: 'referralCode', type: 'uint256' },
+      { internalType: 'uint128', name: 'lockPeriod', type: 'uint128' },
     ],
     name: 'depositETH',
     outputs: [],

--- a/lib/contracts/addresses.ts
+++ b/lib/contracts/addresses.ts
@@ -16,7 +16,7 @@ export const CONTRACT_ADDRESSES = {
     PufferDepositor: '0x824AC05aeb86A0aD770b8acDe0906d2d4a6c4A8c',
     // TODO: Update the addresses once the contracts are deployed on chain.
     // See https://dev.azure.com/pufferfi/Frontend/_workitems/edit/1797.
-    PufferL2Depositor: '0x300480bf80b1ad93a9f6349623646142776e9156',
-    PufLocker: '0x367551e0834c26e29e0a17ce3ed4dca87ff0c204',
+    PufferL2Depositor: '0x0df3f7328761d4122bd8456474305d3259e51699',
+    PufLocker: '0x2764d89cb5b0dfe4cb9103e23257568bebb3afba',
   },
 };

--- a/lib/contracts/handlers/puf-locker-handler.test.ts
+++ b/lib/contracts/handlers/puf-locker-handler.test.ts
@@ -68,6 +68,7 @@ describe('PufTokenHandler', () => {
     const { transact, estimate } = await handler.deposit({
       token: PufToken.pufWETH,
       account: mockAccount,
+      recipient: mockAccount,
       value: 1n,
       lockPeriod: 10n,
       isPreapproved: true,
@@ -86,6 +87,7 @@ describe('PufTokenHandler', () => {
     const { transact, estimate } = await handler.deposit({
       token: PufToken.pufWETH,
       account: mockAccount,
+      recipient: mockAccount,
       value: 1n,
       lockPeriod: 10n,
     });

--- a/lib/contracts/handlers/puf-locker-handler.test.ts
+++ b/lib/contracts/handlers/puf-locker-handler.test.ts
@@ -65,12 +65,13 @@ describe('PufTokenHandler', () => {
       .spyOn((handler as any).erc20PermitHandler, 'getPermitSignature')
       .mockReturnValue(Promise.resolve(mockPermitSignature));
 
-    const { transact, estimate } = await handler.depositPreApproved(
-      PufToken.pufWETH,
-      mockAccount,
-      1n,
-      10n,
-    );
+    const { transact, estimate } = await handler.deposit({
+      token: PufToken.pufWETH,
+      account: mockAccount,
+      value: 1n,
+      lockPeriod: 10n,
+      isPreapproved: true,
+    });
 
     expect(typeof (await estimate())).toBe('bigint');
     expect(isHash(await transact())).toBe(true);
@@ -82,12 +83,12 @@ describe('PufTokenHandler', () => {
       .spyOn((handler as any).erc20PermitHandler, 'getPermitSignature')
       .mockReturnValue(Promise.resolve(mockPermitSignature));
 
-    const { transact, estimate } = await handler.deposit(
-      PufToken.pufWETH,
-      mockAccount,
-      1n,
-      10n,
-    );
+    const { transact, estimate } = await handler.deposit({
+      token: PufToken.pufWETH,
+      account: mockAccount,
+      value: 1n,
+      lockPeriod: 10n,
+    });
 
     expect(typeof (await estimate())).toBe('bigint');
     expect(isHash(await transact())).toBe(true);

--- a/lib/contracts/handlers/puf-locker-handler.ts
+++ b/lib/contracts/handlers/puf-locker-handler.ts
@@ -8,6 +8,7 @@ import { ERC20PermitHandler } from './erc20-permit-handler';
 export type LockerDepositParams = {
   token: PufToken;
   account: Address;
+  recipient: Address;
   value: bigint;
   lockPeriod: bigint;
   isPreapproved?: boolean;
@@ -130,6 +131,7 @@ export class PufLockerHandler {
     const {
       token,
       account,
+      recipient,
       value,
       lockPeriod,
       isPreapproved = false,
@@ -165,6 +167,7 @@ export class PufLockerHandler {
 
     const depositArgs = <const>[
       TOKENS_ADDRESSES[token][this.chain],
+      recipient,
       lockPeriod,
       permitData,
     ];

--- a/lib/contracts/handlers/puffer-l2-depositor-handler.test.ts
+++ b/lib/contracts/handlers/puffer-l2-depositor-handler.test.ts
@@ -30,11 +30,12 @@ describe('PufferL2DepositorHandler', () => {
   it('should deposit pre-approved token', async () => {
     contractTestingUtils.mockTransaction('deposit');
 
-    const { transact, estimate } = handler.depositPreApproved(
-      Token.stETH,
-      mockAccount,
-      10n,
-    );
+    const { transact, estimate } = await handler.deposit({
+      token: Token.stETH,
+      account: mockAccount,
+      value: 10n,
+      isPreapproved: true,
+    });
 
     expect(typeof (await estimate())).toBe('bigint');
     expect(isHash(await transact())).toBe(true);
@@ -46,11 +47,11 @@ describe('PufferL2DepositorHandler', () => {
       .spyOn((handler as any).erc20PermitHandler, 'getPermitSignature')
       .mockReturnValue(Promise.resolve(mockPermitSignature));
 
-    const { transact, estimate } = await handler.deposit(
-      Token.stETH,
-      mockAccount,
-      10n,
-    );
+    const { transact, estimate } = await handler.deposit({
+      token: Token.stETH,
+      account: mockAccount,
+      value: 10n,
+    });
 
     expect(typeof (await estimate())).toBe('bigint');
     expect(isHash(await transact())).toBe(true);

--- a/lib/contracts/handlers/puffer-l2-depositor-handler.ts
+++ b/lib/contracts/handlers/puffer-l2-depositor-handler.ts
@@ -78,8 +78,8 @@ export class PufferL2DepositorHandler {
    * @param depositParams.referralCode Referral code for the deposit.
    * @param depositParams.lockPeriod The period for the deposit in
    * seconds.
-   * @param depositParams.isPreapproved Whether token is pre-approved or
-   * needs a permit.
+   * @param depositParams.isPreapproved Whether the token is
+   * pre-approved or needs a permit.
    * @returns `transact: () => Promise<Address>` - Used to make the
    * transaction.
    *

--- a/lib/contracts/tokens.ts
+++ b/lib/contracts/tokens.ts
@@ -109,7 +109,7 @@ export const TOKENS_ADDRESSES: {
   },
   [PufToken.pufpufETH]: {
     [Chain.Mainnet]: '0x0000000000000000000000000000000000000000',
-    [Chain.Holesky]: '0xECa244cBBe52A68EB6c4fdC266c2c50D568bcd22',
+    [Chain.Holesky]: '0x2de087ab00e427aa7c7e94f5ae6ceb129625f87c',
   },
 };
 

--- a/lib/contracts/tokens.ts
+++ b/lib/contracts/tokens.ts
@@ -68,7 +68,7 @@ export const TOKENS_ADDRESSES: {
   },
   [Token.pufETH]: {
     [Chain.Mainnet]: '0xd9a442856c234a39a81a089c06451ebaa4306a72',
-    [Chain.Holesky]: '0x9196830bb4c05504e0a8475a0ad566aceeb6bec9',
+    [Chain.Holesky]: '0x9196830bB4c05504E0A8475A0aD566AceEB6BeC9',
   },
 
   // TODO: Update the addresses once the contracts are deployed on chain.
@@ -81,11 +81,11 @@ export const TOKENS_ADDRESSES: {
   },
   [PufToken.pufUSDC]: {
     [Chain.Mainnet]: '0x0000000000000000000000000000000000000000',
-    [Chain.Holesky]: '0xC4731029b6F4fEd5930A56F0FFa3E8Ae688f9dA8',
+    [Chain.Holesky]: '0x6D900a9f5784A2cA0004B5c3D3e08D7A9cE4A1b3',
   },
   [PufToken.pufDAI]: {
     [Chain.Mainnet]: '0x0000000000000000000000000000000000000000',
-    [Chain.Holesky]: '0xcA1C3DBC6Ea41f018B8d91C3AbE6FacDBDd4F63e',
+    [Chain.Holesky]: '0x28177665f597DA2dcF43c3680cc40D855672A700',
   },
   [PufToken.pufEETH]: {
     [Chain.Mainnet]: '0x0000000000000000000000000000000000000000',
@@ -93,7 +93,7 @@ export const TOKENS_ADDRESSES: {
   },
   [PufToken.pufWETH]: {
     [Chain.Mainnet]: '0x0000000000000000000000000000000000000000',
-    [Chain.Holesky]: '0x2207119500757bDD269F98d86Dca6356535b876E',
+    [Chain.Holesky]: '0x1E1Aaeff72905B682b9CEc5bC6D3425087df9edf',
   },
   [PufToken.pufStETH]: {
     [Chain.Mainnet]: '0x0000000000000000000000000000000000000000',
@@ -109,14 +109,14 @@ export const TOKENS_ADDRESSES: {
   },
   [PufToken.pufpufETH]: {
     [Chain.Mainnet]: '0x0000000000000000000000000000000000000000',
-    [Chain.Holesky]: '0x2de087ab00e427aa7c7e94f5ae6ceb129625f87c',
+    [Chain.Holesky]: '0x2dE087aB00E427aa7c7e94f5ae6ceB129625F87c',
   },
 };
 
 export const TOKENS_PERMIT_VERSION: { [key in Token | PufToken]: string } = {
   [Token.USDT]: '2',
   // USDC does not support permit signatures (ERC20Permit).
-  [Token.USDC]: '2',
+  [Token.USDC]: '',
   [Token.DAI]: '1',
   [Token.ETH]: '',
   // WETH does not support permit signatures (ERC20Permit).


### PR DESCRIPTION
The PufferL2Depositor and PufLocker contracts are now optimized so that only one transaction is needed for staking and locking.

The contracts have been updated in the SDK along with the addresses of some tokens which have been redeployed.

The PR also improves the handlers so a single method is used to process tokens that are pre-approved or require a permit signature.