### PR TITLE
1951: Remove permit version for DAI

### DIFF
--- a/lib/contracts/tokens.ts
+++ b/lib/contracts/tokens.ts
@@ -117,7 +117,8 @@ export const TOKENS_PERMIT_VERSION: { [key in Token | PufToken]: string } = {
   [Token.USDT]: '2',
   // USDC does not support permit signatures (ERC20Permit).
   [Token.USDC]: '',
-  [Token.DAI]: '1',
+  // DAI does not support permit signatures (ERC20Permit).
+  [Token.DAI]: '',
   [Token.ETH]: '',
   // WETH does not support permit signatures (ERC20Permit).
   [Token.WETH]: '',


### PR DESCRIPTION
DAI uses a specific way to generate a permit for a spender to use DAI. Since the contracts that we have don't handle those permits, we are removing DAI from the list of tokens that support permits and pre-approval should be used when using DAI tokens.