### PR TITLE
Handle permit for tokens internally when depositing through nucleus's Teller contract

### DIFF
--- a/lib/contracts/tokens.ts
+++ b/lib/contracts/tokens.ts
@@ -92,7 +92,8 @@ export const TOKENS_PERMIT_VERSION: { [key in AnyToken]: string } = {
   [Token.pufETH]: '1',
 
   // UniFi Tokens
-  [UnifiToken.unifiETH]: '',
+  // https://etherscan.io/address/0x196ead472583bc1e9af7a05f860d9857e1bd3dcc#code#F7#L172
+  [UnifiToken.unifiETH]: '1',
 };
 
 export const TOKENS_SALT: Partial<{


### PR DESCRIPTION
This is an improvement to handle permit signatures for nucleus internally in the SDK like the `PufLocker` contract.