### PR TITLE
AB#3412: Update PufLocker contract handler to accept any token

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,6 +12,7 @@ export default [
   {
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',
+      'no-duplicate-imports': 'error',
     },
   },
 ];

--- a/lib/contracts/handlers/puf-locker-handler.test.ts
+++ b/lib/contracts/handlers/puf-locker-handler.test.ts
@@ -7,7 +7,7 @@ import {
 import { mockAccount, testingUtils } from '../../../test/setup-tests';
 import { Chain } from '../../chains/constants';
 import { PUF_LOCKER_ABIS } from '../abis/puf-locker-abis';
-import { UnifiToken } from '../tokens';
+import { Token } from '../tokens';
 import { PufLockerHandler } from './puf-locker-handler';
 
 describe('PufTokenHandler', () => {
@@ -27,10 +27,7 @@ describe('PufTokenHandler', () => {
     const mockDeposit = { amount: 1n, releaseTime: 1n };
     contractTestingUtils.mockCall('getAllDeposits', [[mockDeposit]]);
 
-    const allDeposits = await handler.getAllDeposits(
-      UnifiToken.unifiETH,
-      mockAccount,
-    );
+    const allDeposits = await handler.getAllDeposits(Token.CARROT, mockAccount);
 
     expect(allDeposits).toEqual([mockDeposit]);
   });
@@ -40,7 +37,7 @@ describe('PufTokenHandler', () => {
     contractTestingUtils.mockCall('getDeposits', [[mockDeposit]]);
 
     const allDeposits = await handler.getDeposits(
-      UnifiToken.unifiETH,
+      Token.CARROT,
       mockAccount,
       0n,
       1n,
@@ -66,7 +63,7 @@ describe('PufTokenHandler', () => {
       .mockReturnValue(Promise.resolve(mockPermitSignature));
 
     const { transact, estimate } = await handler.deposit({
-      token: UnifiToken.unifiETH,
+      token: Token.CARROT,
       account: mockAccount,
       recipient: mockAccount,
       value: 1n,
@@ -85,7 +82,7 @@ describe('PufTokenHandler', () => {
       .mockReturnValue(Promise.resolve(mockPermitSignature));
 
     const { transact, estimate } = await handler.deposit({
-      token: UnifiToken.unifiETH,
+      token: Token.CARROT,
       account: mockAccount,
       recipient: mockAccount,
       value: 1n,
@@ -100,7 +97,7 @@ describe('PufTokenHandler', () => {
     contractTestingUtils.mockTransaction('withdraw');
 
     const { transact, estimate } = handler.withdraw(
-      UnifiToken.unifiETH,
+      Token.CARROT,
       mockAccount,
       mockAccount,
       [0n],

--- a/lib/contracts/handlers/puf-locker-handler.ts
+++ b/lib/contracts/handlers/puf-locker-handler.ts
@@ -9,11 +9,11 @@ import {
 import { Chain, VIEM_CHAINS, ViemChain } from '../../chains/constants';
 import { PUF_LOCKER_ABIS } from '../abis/puf-locker-abis';
 import { CONTRACT_ADDRESSES } from '../addresses';
-import { UnifiToken, TOKENS_ADDRESSES } from '../tokens';
+import { AnyToken, TOKENS_ADDRESSES } from '../tokens';
 import { ERC20PermitHandler } from './erc20-permit-handler';
 
 export type LockerDepositParams = {
-  token: UnifiToken;
+  token: AnyToken;
   account: Address;
   recipient: Address;
   value: bigint;
@@ -77,7 +77,7 @@ export class PufLockerHandler {
    * @param walletAddress The wallet address to get the deposits for.
    * @returns The amount and deposits of the given account address.
    */
-  public getAllDeposits(pufToken: UnifiToken, walletAddress: Address) {
+  public getAllDeposits(pufToken: AnyToken, walletAddress: Address) {
     return this.getContract().read.getAllDeposits([
       TOKENS_ADDRESSES[pufToken][this.chain],
       walletAddress,
@@ -94,7 +94,7 @@ export class PufLockerHandler {
    * @returns The amount and release time of the deposits.
    */
   public getDeposits(
-    pufToken: UnifiToken,
+    pufToken: AnyToken,
     userAddress: Address,
     start: bigint,
     limit: bigint,
@@ -205,7 +205,7 @@ export class PufLockerHandler {
    * @returns Hash of the withdrawal transaction.
    */
   public withdraw(
-    pufToken: UnifiToken,
+    pufToken: AnyToken,
     walletAddress: Address,
     recipient: Address,
     depositIndexes: bigint[],


### PR DESCRIPTION
…okens

<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Previously the contract only worked for UnifiTokens. It's not been updated to support any token.

#### Which issue(s) does this PR fixes:

<!--  For internal Puffer folks, please tag this PR to an internal user story ID for traceability -->

AB#3412

#### Additional comments:
