### PR TITLE
AB#3671: Disable permit for slvlUSD

### DIFF
--- a/lib/contracts/tokens.ts
+++ b/lib/contracts/tokens.ts
@@ -215,7 +215,9 @@ export const TOKENS_PERMIT_VERSION: { [key in AnyToken]: string } = {
   [Token.vePUFFER]: '1',
   [Token.CARROT]: '1',
   [Token.lvlUSD]: '1',
-  [Token.slvlUSD]: '1',
+  // `slvlUSD` supports permit but the transactions are reverting now
+  // for some reason.
+  [Token.slvlUSD]: '',
   [Token.mtwCARROT]: '',
   [Token.sCARROT]: '',
   [Token.LINK]: '',


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

The permit is failing with same logic that we use for other tokens like `lvlUSD`. So we are removing permit support for `slvlUSD` until we figure out why it's happening.

#### Which issue(s) does this PR fixes:

<!--  For internal Puffer folks, please tag this PR to an internal user story ID for traceability -->

[AB#3671](https://dev.azure.com/pufferfi/7ec516e5-cd36-448b-914b-0ffdf2fabd74/_workitems/edit/3671)

#### Additional comments:
