### PR TITLE
Add puffer oracle v2 handler

### DIFF
--- a/lib/api/puffer-client.ts
+++ b/lib/api/puffer-client.ts
@@ -23,6 +23,7 @@ import { CarrotStakingHandler } from '../contracts/handlers/carrot-staking-handl
 import { DistributorHandler } from '../contracts/handlers/distributor-handler';
 import { ConcreteVaultHandler } from '../contracts/handlers/concrete-vault-handler';
 import { ValidatorTicketHandler } from '../contracts/handlers/validator-ticket-handler';
+import { PufferOracleV2Handler } from '../contracts/handlers/puffer-oracle-v2-handler';
 
 /**
  * The core class and the main entry point of the Puffer SDK.
@@ -66,6 +67,8 @@ export class PufferClient {
   public concreteVault: ConcreteVaultHandler;
   /** Handler for the `ValidatorTicket` contract. */
   public validatorTicket: ValidatorTicketHandler;
+  /** Handler for the `PufferOracleV2` contract. */
+  public pufferOracleV2: PufferOracleV2Handler;
 
   /**
    * Create the Puffer Client.
@@ -178,6 +181,11 @@ export class PufferClient {
       this.publicClient,
     );
     this.validatorTicket = new ValidatorTicketHandler(
+      chain,
+      this.walletClient,
+      this.publicClient,
+    );
+    this.pufferOracleV2 = new PufferOracleV2Handler(
       chain,
       this.walletClient,
       this.publicClient,

--- a/lib/contracts/abis/mainnet/PufferOracleV2.ts
+++ b/lib/contracts/abis/mainnet/PufferOracleV2.ts
@@ -1,0 +1,149 @@
+export const PufferOracleV2 = <const>[
+  {
+    inputs: [
+      {
+        internalType: 'contract IGuardianModule',
+        name: 'guardianModule',
+        type: 'address',
+      },
+      { internalType: 'address payable', name: 'vault', type: 'address' },
+      { internalType: 'address', name: 'accessManager', type: 'address' },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'constructor',
+  },
+  {
+    inputs: [{ internalType: 'address', name: 'authority', type: 'address' }],
+    name: 'AccessManagedInvalidAuthority',
+    type: 'error',
+  },
+  {
+    inputs: [
+      { internalType: 'address', name: 'caller', type: 'address' },
+      { internalType: 'uint32', name: 'delay', type: 'uint32' },
+    ],
+    name: 'AccessManagedRequiredDelay',
+    type: 'error',
+  },
+  {
+    inputs: [{ internalType: 'address', name: 'caller', type: 'address' }],
+    name: 'AccessManagedUnauthorized',
+    type: 'error',
+  },
+  { inputs: [], name: 'InvalidUpdate', type: 'error' },
+  { inputs: [], name: 'InvalidValidatorTicketPrice', type: 'error' },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'oldPrice',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'newPrice',
+        type: 'uint256',
+      },
+    ],
+    name: 'ValidatorTicketMintPriceUpdated',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'oldNumberOfValidators',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'newNumberOfValidators',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'epochNumber',
+        type: 'uint256',
+      },
+    ],
+    name: 'TotalNumberOfValidatorsUpdated',
+    type: 'event',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'numberOfExits', type: 'uint256' },
+    ],
+    name: 'exitValidators',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'getLockedEthAmount',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'getTotalNumberOfValidators',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'getValidatorTicketPrice',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'isOverBurstThreshold',
+    outputs: [{ internalType: 'bool', name: '', type: 'bool' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'provisionNode',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'uint256', name: 'newPrice', type: 'uint256' }],
+    name: 'setMintPrice',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'newTotalNumberOfValidators',
+        type: 'uint256',
+      },
+      { internalType: 'uint256', name: 'epochNumber', type: 'uint256' },
+      {
+        internalType: 'bytes[]',
+        name: 'guardianEOASignatures',
+        type: 'bytes[]',
+      },
+    ],
+    name: 'setTotalNumberOfValidators',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+];

--- a/lib/contracts/addresses.ts
+++ b/lib/contracts/addresses.ts
@@ -19,6 +19,7 @@ export const CONTRACT_ADDRESSES = {
     CarrotStaker: '0x99c599227c65132822f0290d9e5b4b0430d6c0d6',
     Distributor: '0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae',
     ValidatorTicket: '0x7D26AD6F6BA9D6bA1de0218Ae5e20CD3a273a55A',
+    PufferOracleV2: '0x0BE2aE0edbeBb517541DF217EF0074FC9a9e994f',
   },
   [Chain.Holesky as number]: {
     PufferVault: '0x9196830bB4c05504E0A8475A0aD566AceEB6BeC9',
@@ -29,6 +30,7 @@ export const CONTRACT_ADDRESSES = {
     L2RewardManager: '0x58C046794f69A8830b0BE737022a45b4acd01dE5',
     PufferWithdrawalManager: '0x5A3E1069B66800c0ecbc91bd81b1AE4D1804DBc4',
     ValidatorTicket: '0x7D26AD6F6BA9D6bA1de0218Ae5e20CD3a273a55A',
+    PufferOracleV2: '0x8e043ed3f06720615685d4978770cd5c8fe90fe3',
   },
   [Chain.Base as number]: {
     L2RewardManager: '0xF9Dd335bF363b2E4ecFe3c94A86EBD7Dd3Dcf0e7',

--- a/lib/contracts/handlers/__tests__/puffer-oracle-v2-handler.test.ts
+++ b/lib/contracts/handlers/__tests__/puffer-oracle-v2-handler.test.ts
@@ -1,0 +1,215 @@
+import { Chain } from '../../../chains/constants';
+import { PufferOracleV2Handler } from '../puffer-oracle-v2-handler';
+import { PufferOracleV2 } from '../../abis/mainnet/PufferOracleV2';
+import { CONTRACT_ADDRESSES } from '../../addresses';
+
+describe('PufferOracleV2Handler', () => {
+  const mockWalletClient = {
+    account: '0x123',
+  };
+  const mockPublicClient = {};
+  const mockChain = Chain.Mainnet;
+
+  const mockContract = {
+    address: CONTRACT_ADDRESSES[Chain.Mainnet].PufferOracleV2,
+    abi: PufferOracleV2,
+    read: {
+      getValidatorTicketPrice: jest.fn(),
+      getTotalNumberOfValidators: jest.fn(),
+      getLockedEthAmount: jest.fn(),
+      isOverBurstThreshold: jest.fn(),
+    },
+    write: {
+      provisionNode: jest.fn(),
+      exitValidators: jest.fn(),
+      setMintPrice: jest.fn(),
+      setTotalNumberOfValidators: jest.fn(),
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('constructor', () => {
+    it('should initialize correctly', () => {
+      const handler = new PufferOracleV2Handler(
+        mockChain,
+        mockWalletClient as any,
+        mockPublicClient as any,
+      );
+      expect(handler).toBeDefined();
+    });
+  });
+
+  describe('getContract', () => {
+    it('should return the contract with correct configuration', () => {
+      const handler = new PufferOracleV2Handler(
+        mockChain,
+        mockWalletClient as any,
+        mockPublicClient as any,
+      );
+      const result = handler.getContract();
+
+      expect(result.address).toBe(
+        CONTRACT_ADDRESSES[Chain.Mainnet].PufferOracleV2,
+      );
+      expect(result.abi).toBe(PufferOracleV2);
+      expect(result.read).toBeDefined();
+      expect(result.write).toBeDefined();
+    });
+  });
+
+  describe('getValidatorTicketPrice', () => {
+    it('should call contract getValidatorTicketPrice', async () => {
+      const handler = new PufferOracleV2Handler(
+        mockChain,
+        mockWalletClient as any,
+        mockPublicClient as any,
+      );
+      handler['getContract'] = jest.fn().mockReturnValue(mockContract);
+
+      await handler.getValidatorTicketPrice();
+
+      expect(mockContract.read.getValidatorTicketPrice).toHaveBeenCalled();
+    });
+  });
+
+  describe('getTotalNumberOfValidators', () => {
+    it('should call contract getTotalNumberOfValidators', async () => {
+      const handler = new PufferOracleV2Handler(
+        mockChain,
+        mockWalletClient as any,
+        mockPublicClient as any,
+      );
+      handler['getContract'] = jest.fn().mockReturnValue(mockContract);
+
+      await handler.getTotalNumberOfValidators();
+
+      expect(mockContract.read.getTotalNumberOfValidators).toHaveBeenCalled();
+    });
+  });
+
+  describe('getLockedEthAmount', () => {
+    it('should call contract getLockedEthAmount', async () => {
+      const handler = new PufferOracleV2Handler(
+        mockChain,
+        mockWalletClient as any,
+        mockPublicClient as any,
+      );
+      handler['getContract'] = jest.fn().mockReturnValue(mockContract);
+
+      await handler.getLockedEthAmount();
+
+      expect(mockContract.read.getLockedEthAmount).toHaveBeenCalled();
+    });
+  });
+
+  describe('isOverBurstThreshold', () => {
+    it('should call contract isOverBurstThreshold', async () => {
+      const handler = new PufferOracleV2Handler(
+        mockChain,
+        mockWalletClient as any,
+        mockPublicClient as any,
+      );
+      handler['getContract'] = jest.fn().mockReturnValue(mockContract);
+
+      await handler.isOverBurstThreshold();
+
+      expect(mockContract.read.isOverBurstThreshold).toHaveBeenCalled();
+    });
+  });
+
+  describe('provisionNode', () => {
+    it('should call contract provisionNode with correct parameters', async () => {
+      const handler = new PufferOracleV2Handler(
+        mockChain,
+        mockWalletClient as any,
+        mockPublicClient as any,
+      );
+      handler['getContract'] = jest.fn().mockReturnValue(mockContract);
+
+      await handler.provisionNode();
+
+      expect(mockContract.write.provisionNode).toHaveBeenCalledWith({
+        account: mockWalletClient.account,
+        chain: expect.any(Object),
+      });
+    });
+  });
+
+  describe('exitValidators', () => {
+    it('should call contract exitValidators with correct parameters', async () => {
+      const handler = new PufferOracleV2Handler(
+        mockChain,
+        mockWalletClient as any,
+        mockPublicClient as any,
+      );
+      handler['getContract'] = jest.fn().mockReturnValue(mockContract);
+
+      const numberOfExits = 5n;
+      await handler.exitValidators(numberOfExits);
+
+      expect(mockContract.write.exitValidators).toHaveBeenCalledWith(
+        [numberOfExits],
+        {
+          account: mockWalletClient.account,
+          chain: expect.any(Object),
+        },
+      );
+    });
+  });
+
+  describe('setMintPrice', () => {
+    it('should call contract setMintPrice with correct parameters', async () => {
+      const handler = new PufferOracleV2Handler(
+        mockChain,
+        mockWalletClient as any,
+        mockPublicClient as any,
+      );
+      handler['getContract'] = jest.fn().mockReturnValue(mockContract);
+
+      const newPrice = 1000000000000000000n; // 1 ETH
+      await handler.setMintPrice(newPrice);
+
+      expect(mockContract.write.setMintPrice).toHaveBeenCalledWith([newPrice], {
+        account: mockWalletClient.account,
+        chain: expect.any(Object),
+      });
+    });
+  });
+
+  describe('setTotalNumberOfValidators', () => {
+    it('should call contract setTotalNumberOfValidators with correct parameters', async () => {
+      const handler = new PufferOracleV2Handler(
+        mockChain,
+        mockWalletClient as any,
+        mockPublicClient as any,
+      );
+      handler['getContract'] = jest.fn().mockReturnValue(mockContract);
+
+      const newTotalNumberOfValidators = 1000n;
+      const epochNumber = 12345n;
+      const guardianEOASignatures = [
+        '0x1234567890123456789012345678901234567890123456789012345678901234',
+        '0x5678901234567890123456789012345678901234567890123456789012345678',
+      ] as `0x${string}`[];
+
+      await handler.setTotalNumberOfValidators(
+        newTotalNumberOfValidators,
+        epochNumber,
+        guardianEOASignatures,
+      );
+
+      expect(
+        mockContract.write.setTotalNumberOfValidators,
+      ).toHaveBeenCalledWith(
+        [newTotalNumberOfValidators, epochNumber, guardianEOASignatures],
+        {
+          account: mockWalletClient.account,
+          chain: expect.any(Object),
+        },
+      );
+    });
+  });
+});

--- a/lib/contracts/handlers/puffer-oracle-v2-handler.ts
+++ b/lib/contracts/handlers/puffer-oracle-v2-handler.ts
@@ -1,0 +1,150 @@
+import {
+  WalletClient,
+  PublicClient,
+  getContract,
+  Address,
+  GetContractReturnType,
+  Account,
+} from 'viem';
+import { Chain, VIEM_CHAINS, ViemChain } from '../../chains/constants';
+import { CONTRACT_ADDRESSES } from '../addresses';
+import { PufferOracleV2 } from '../abis/mainnet/PufferOracleV2';
+
+/**
+ * Handler for the `PufferOracleV2` contract exposing methods to interact
+ * with the contract.
+ */
+export class PufferOracleV2Handler {
+  private viemChain: ViemChain;
+
+  /**
+   * Create the handler for the `PufferOracleV2` contract exposing
+   * methods to interact with the contract.
+   *
+   * @param chain Chain to use for the client.
+   * @param walletClient The wallet client to use for wallet
+   * interactions.
+   * @param publicClient The public client to use for public
+   * interactions.
+   */
+  constructor(
+    private chain: Chain,
+    private walletClient: WalletClient,
+    private publicClient: PublicClient,
+  ) {
+    this.viemChain = VIEM_CHAINS[chain];
+  }
+
+  /**
+   * Get the contract.
+   *
+   * @returns The viem contract.
+   */
+  public getContract() {
+    const address = CONTRACT_ADDRESSES[this.chain].PufferOracleV2 as Address;
+    const abi = PufferOracleV2;
+    const client = { public: this.publicClient, wallet: this.walletClient };
+
+    return getContract({ address, abi, client }) as GetContractReturnType<
+      typeof abi,
+      typeof client,
+      Address
+    >;
+  }
+
+  /**
+   * Get the validator ticket price.
+   *
+   * @returns The validator ticket price.
+   */
+  public getValidatorTicketPrice() {
+    return this.getContract().read.getValidatorTicketPrice();
+  }
+
+  /**
+   * Get the total number of validators.
+   *
+   * @returns The total number of validators.
+   */
+  public getTotalNumberOfValidators() {
+    return this.getContract().read.getTotalNumberOfValidators();
+  }
+
+  /**
+   * Get the locked ETH amount.
+   *
+   * @returns The locked ETH amount.
+   */
+  public getLockedEthAmount() {
+    return this.getContract().read.getLockedEthAmount();
+  }
+
+  /**
+   * Check if the system is over burst threshold.
+   *
+   * @returns True if over burst threshold.
+   */
+  public isOverBurstThreshold() {
+    return this.getContract().read.isOverBurstThreshold();
+  }
+
+  /**
+   * Provision a new node.
+   *
+   * @returns The transaction.
+   */
+  public provisionNode() {
+    return this.getContract().write.provisionNode({
+      account: this.walletClient.account as Account,
+      chain: this.viemChain,
+    });
+  }
+
+  /**
+   * Exit validators.
+   *
+   * @param numberOfExits The number of validators to exit.
+   * @returns The transaction.
+   */
+  public exitValidators(numberOfExits: bigint) {
+    return this.getContract().write.exitValidators([numberOfExits], {
+      account: this.walletClient.account as Account,
+      chain: this.viemChain,
+    });
+  }
+
+  /**
+   * Set the mint price for validator tickets.
+   *
+   * @param newPrice The new mint price.
+   * @returns The transaction.
+   */
+  public setMintPrice(newPrice: bigint) {
+    return this.getContract().write.setMintPrice([newPrice], {
+      account: this.walletClient.account as Account,
+      chain: this.viemChain,
+    });
+  }
+
+  /**
+   * Set the total number of validators.
+   *
+   * @param newTotalNumberOfValidators The new total number of validators.
+   * @param epochNumber The epoch number.
+   * @param guardianEOASignatures The guardian EOA signatures.
+   * @returns The transaction.
+   */
+  public setTotalNumberOfValidators(
+    newTotalNumberOfValidators: bigint,
+    epochNumber: bigint,
+    guardianEOASignatures: `0x${string}`[],
+  ) {
+    return this.getContract().write.setTotalNumberOfValidators(
+      [newTotalNumberOfValidators, epochNumber, guardianEOASignatures],
+      {
+        account: this.walletClient.account as Account,
+        chain: this.viemChain,
+      },
+    );
+  }
+}

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -15,3 +15,4 @@ export * from './contracts/handlers/puffer-withdrawal-manager-handler';
 export * from './contracts/handlers/distributor-handler';
 export * from './contracts/handlers/concrete-vault-handler';
 export * from './contracts/handlers/validator-ticket-handler';
+export * from './contracts/handlers/puffer-oracle-v2-handler';


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Adds the oracle handler so we can fetch VT price and other VT stats without wallet being connected.

#### Which issue(s) does this PR fixes:

<!--  For internal Puffer folks, please tag this PR to an internal user story ID for traceability -->



#### Additional comments:
